### PR TITLE
Add sidebar GUI with shape loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ With inheriting GraphicDrawer abstract class, you can create new graphic drawers
 
 PygameGraphicDrawer is a concrete implementation of GraphicDrawer abstract class. It uses PyGame to draw the points on the screen.
 
+### GUI application
+You can run `app.py` to launch a small GUI with a side bar. Select the shape from
+the dropdown, set the iteration count (default is 100000) and press **Run** to
+start the simulation.
+
 
 ## Built-in shapes
 ### Sierpinski triangle

--- a/app.py
+++ b/app.py
@@ -1,0 +1,77 @@
+import pygame
+import pygame_gui
+
+from shapes import load_shape, DEFAULT_ITERATIONS
+from graphics import PygameGraphicDrawer
+
+
+class ChaosGameApp:
+    def __init__(self, width: int = 1280, height: int = 800, fullscreen: bool = False):
+        pygame.init()
+        self.width = width
+        self.height = height
+        self.fullscreen = fullscreen
+        flags = pygame.FULLSCREEN if fullscreen else 0
+        self.screen = pygame.display.set_mode((self.width, self.height), flags)
+        pygame.display.set_caption("Chaos Game")
+        self.manager = pygame_gui.UIManager((self.width, self.height))
+
+        self.shape_dropdown = pygame_gui.elements.UIDropDownMenu(
+            ["Barnsley Fern", "Sierpinski Triangle"],
+            "Barnsley Fern",
+            relative_rect=pygame.Rect(10, 10, 200, 30),
+            manager=self.manager,
+        )
+        self.iter_input = pygame_gui.elements.UITextEntryLine(
+            relative_rect=pygame.Rect(10, 50, 200, 30),
+            manager=self.manager,
+        )
+        self.iter_input.set_text(str(DEFAULT_ITERATIONS))
+        self.run_button = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(10, 90, 200, 30),
+            text="Run",
+            manager=self.manager,
+        )
+        self.clock = pygame.time.Clock()
+
+    def event_loop(self):
+        running = True
+        while running:
+            time_delta = self.clock.tick(60) / 1000.0
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                if event.type == pygame.USEREVENT:
+                    if (
+                        event.user_type == pygame_gui.UI_BUTTON_PRESSED
+                        and event.ui_element == self.run_button
+                    ):
+                        self.start_simulation()
+                self.manager.process_events(event)
+            self.manager.update(time_delta)
+            self.screen.fill((0, 0, 0))
+            self.manager.draw_ui(self.screen)
+            pygame.display.flip()
+        pygame.quit()
+
+    def start_simulation(self):
+        shape_name = self.shape_dropdown.selected_option
+        try:
+            iteration_count = int(self.iter_input.get_text())
+        except ValueError:
+            iteration_count = DEFAULT_ITERATIONS
+        shape = load_shape(shape_name, iteration_count)
+        drawer = PygameGraphicDrawer(
+            shape,
+            self.width,
+            self.height,
+            self.fullscreen,
+            shape_name,
+            max_iteration_count=iteration_count,
+        )
+        drawer.draw()
+
+
+if __name__ == "__main__":
+    app = ChaosGameApp()
+    app.event_loop()

--- a/app.py
+++ b/app.py
@@ -32,6 +32,8 @@ class ChaosGameApp:
             text="Run",
             manager=self.manager,
         )
+        self.drawer: PygameGraphicDrawer | None = None
+        self.simulation_running = False
         self.clock = pygame.time.Clock()
 
     def event_loop(self):
@@ -46,10 +48,22 @@ class ChaosGameApp:
                         event.user_type == pygame_gui.UI_BUTTON_PRESSED
                         and event.ui_element == self.run_button
                     ):
-                        self.start_simulation()
+                        if not self.simulation_running:
+                            self.start_simulation()
+                        else:
+                            self.stop_simulation()
+                if self.simulation_running and self.drawer:
+                    self.drawer.process_event(event)
+
                 self.manager.process_events(event)
+            if self.simulation_running and self.drawer:
+                self.drawer.update()
+                if not self.drawer.running:
+                    self.stop_simulation()
+            else:
+                self.screen.fill((0, 0, 0))
+
             self.manager.update(time_delta)
-            self.screen.fill((0, 0, 0))
             self.manager.draw_ui(self.screen)
             pygame.display.flip()
         pygame.quit()
@@ -62,15 +76,24 @@ class ChaosGameApp:
             iteration_count = DEFAULT_ITERATIONS
         shape_name = shape_name[0]
         shape = load_shape(shape_name, iteration_count)
-        drawer = PygameGraphicDrawer(
+        self.drawer = PygameGraphicDrawer(
             shape,
             self.width,
             self.height,
             self.fullscreen,
             shape_name,
             max_iteration_count=iteration_count,
+            screen=self.screen,
         )
-        drawer.draw()
+        self.simulation_running = True
+        self.run_button.set_text("Stop")
+
+    def stop_simulation(self):
+        if self.drawer:
+            self.drawer.stop()
+            self.drawer = None
+        self.simulation_running = False
+        self.run_button.set_text("Run")
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ class ChaosGameApp:
             iteration_count = int(self.iter_input.get_text())
         except ValueError:
             iteration_count = DEFAULT_ITERATIONS
+        shape_name = shape_name[0]
         shape = load_shape(shape_name, iteration_count)
         drawer = PygameGraphicDrawer(
             shape,

--- a/barnsley_fern.py
+++ b/barnsley_fern.py
@@ -5,14 +5,20 @@ from chaosgame import ChaosGameGraphic
 
 
 class BarnsleyFern(ChaosGameGraphic):
-    def __init__(self, x0, y0):
+    def __init__(self, x0: float, y0: float, max_iteration_count: int = 100000):
         self.starting_point = (x0, y0)
         self.x, self.y = self.starting_point
         self.shape_color = "green"
+        self.max_iteration_count = max_iteration_count
+        self.iteration_count = 0
 
     def __next__(self):
+        if self.iteration_count >= self.max_iteration_count:
+            raise StopIteration
+
         next_func = self.next_func
         self.x, self.y = next_func()
+        self.iteration_count += 1
         return self.x, self.y
 
     def func_1(self):

--- a/graphics.py
+++ b/graphics.py
@@ -12,7 +12,16 @@ class GraphicDrawer(ABC):
         pass
 
 class PygameGraphicDrawer(GraphicDrawer):
-    def __init__(self, graphic: ChaosGameGraphic, screen_width: int, screen_height: int, fullscreen: bool, screen_caption: str, max_iteration_count: int = 100000):
+    def __init__(
+        self,
+        graphic: ChaosGameGraphic,
+        screen_width: int,
+        screen_height: int,
+        fullscreen: bool,
+        screen_caption: str,
+        max_iteration_count: int = 100000,
+        screen: pygame.Surface | None = None,
+    ):
         pygame.init()
 
         super().__init__(graphic)
@@ -22,10 +31,15 @@ class PygameGraphicDrawer(GraphicDrawer):
 
         self.fullscreen = fullscreen
         self.screen_caption = screen_caption
-        self.screen = pygame.display.set_mode(
-            (self.screen_width, self.screen_height),
-            pygame.FULLSCREEN if self.fullscreen else 0
-        )
+        if screen is None:
+            self.screen = pygame.display.set_mode(
+                (self.screen_width, self.screen_height),
+                pygame.FULLSCREEN if self.fullscreen else 0,
+            )
+            self._external_screen = False
+        else:
+            self.screen = screen
+            self._external_screen = True
         pygame.display.set_caption(self.screen_caption)
 
         self.clock = pygame.time.Clock()
@@ -76,7 +90,7 @@ class PygameGraphicDrawer(GraphicDrawer):
 
     def pan(self, dx: int, dy: int):
         self.offset_x += dx
-        self.offset_y -= dy
+        self.offset_y += dy
 
     def start_pan(self, pos: tuple[int, int]):
         self._dragging = True
@@ -106,48 +120,70 @@ class PygameGraphicDrawer(GraphicDrawer):
         # draw shape
         pass
 
+    def process_event(self, event: pygame.event.Event):
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self.start_pan(event.pos)
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            self.end_pan()
+        elif event.type == pygame.MOUSEMOTION:
+            self.pan_drag(event.pos)
+        elif event.type == pygame.MOUSEWHEEL:
+            factor = 1.1 if event.y > 0 else 1 / 1.1
+            self.zoom_at(factor, pygame.mouse.get_pos())
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            self.running = False
+
+    def step(self):
+        if not self.running:
+            return
+        try:
+            self.add_world_point(next(self.graphic))
+        except StopIteration:
+            self.running = False
+            return
+
+        self.iteration_count += 1
+        if self.iteration_count >= self.max_iteration_count:
+            self.running = False
+
+    def render(self):
+        self.screen.fill((0, 0, 0))
+
+        for point in self.points:
+            screen_point = self.world_to_screen(point)
+            pygame.draw.circle(
+                self.screen, self.graphic.shape_color, screen_point, 1
+            )
+
+        self.show_iteration_count(self.iteration_count)
+
+        if not self._external_screen:
+            pygame.display.flip()
+
+    def update(self):
+        self.step()
+        if self.running:
+            self.render()
+        self.clock.tick(500)
+
     def _loop(self):
         while self.running:
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.running = False
-                elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                    self.start_pan(event.pos)
-                elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
-                    self.end_pan()
-                elif event.type == pygame.MOUSEMOTION:
-                    self.pan_drag(event.pos)
-                elif event.type == pygame.MOUSEWHEEL:
-                    factor = 1.1 if event.y > 0 else 1 / 1.1
-                    self.zoom_at(factor, pygame.mouse.get_pos())
-                elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
-                    self.running = False
+                else:
+                    self.process_event(event)
 
-            try:
-                self.add_world_point(next(self.graphic))
-            except StopIteration:
-                self.running = False
-
-            self.screen.fill((0, 0, 0))
-
-            for point in self.points:
-                screen_point = self.world_to_screen(point)
-                pygame.draw.circle(self.screen, self.graphic.shape_color, screen_point, 1)
-
-            self.iteration_count += 1
-            if self.iteration_count >= self.max_iteration_count:
-                self.running = False
-
-            self.show_iteration_count(self.iteration_count)
-
-            pygame.display.flip()
-
-            self.clock.tick(500)
+            self.update()
 
     def _quit(self):
-        pygame.quit()
+        if not self._external_screen:
+            pygame.quit()
 
     def draw(self):
         self._setup()
         self._loop()
         self._quit()
+
+    def stop(self):
+        self.running = False

--- a/graphics.py
+++ b/graphics.py
@@ -76,7 +76,7 @@ class PygameGraphicDrawer(GraphicDrawer):
 
     def pan(self, dx: int, dy: int):
         self.offset_x += dx
-        self.offset_y += dy
+        self.offset_y -= dy
 
     def start_pan(self, pos: tuple[int, int]):
         self._dragging = True

--- a/graphics.py
+++ b/graphics.py
@@ -37,6 +37,8 @@ class PygameGraphicDrawer(GraphicDrawer):
         self.offset_x = 0
         self.offset_y = 0
         self.points: list[tuple[float, float]] = []
+        self._dragging = False
+        self._last_mouse: tuple[int, int] | None = None
 
     def world_to_screen(self, point: tuple[float, float]) -> tuple[int, int]:
         x = point[0] * self.screen_width // 12
@@ -64,9 +66,33 @@ class PygameGraphicDrawer(GraphicDrawer):
     def zoom_out(self, factor: float = 1.1):
         self.zoom /= factor
 
+    def zoom_at(self, factor: float, screen_pos: tuple[int, int]):
+        world = self.screen_to_world(screen_pos)
+        self.zoom *= factor
+        scaled_x = world[0] * self.screen_width // 12
+        scaled_y = world[1] * self.screen_height // 12
+        self.offset_x = screen_pos[0] - scaled_x * self.zoom - self.screen_width // 2
+        self.offset_y = self.screen_height - screen_pos[1] - scaled_y * self.zoom
+
     def pan(self, dx: int, dy: int):
         self.offset_x += dx
         self.offset_y += dy
+
+    def start_pan(self, pos: tuple[int, int]):
+        self._dragging = True
+        self._last_mouse = pos
+
+    def pan_drag(self, pos: tuple[int, int]):
+        if not self._dragging or self._last_mouse is None:
+            return
+        dx = pos[0] - self._last_mouse[0]
+        dy = pos[1] - self._last_mouse[1]
+        self.pan(dx, dy)
+        self._last_mouse = pos
+
+    def end_pan(self):
+        self._dragging = False
+        self._last_mouse = None
 
     def show_iteration_count(self, iteration_count: int):
         surface = pygame.Surface((200, 50), pygame.SRCALPHA)
@@ -85,19 +111,17 @@ class PygameGraphicDrawer(GraphicDrawer):
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.running = False
-                elif event.type == pygame.KEYDOWN:
-                    if event.key in (pygame.K_EQUALS, pygame.K_PLUS, pygame.K_KP_PLUS):
-                        self.zoom_in()
-                    elif event.key in (pygame.K_MINUS, pygame.K_KP_MINUS):
-                        self.zoom_out()
-                    elif event.key == pygame.K_LEFT:
-                        self.pan(-10, 0)
-                    elif event.key == pygame.K_RIGHT:
-                        self.pan(10, 0)
-                    elif event.key == pygame.K_UP:
-                        self.pan(0, -10)
-                    elif event.key == pygame.K_DOWN:
-                        self.pan(0, 10)
+                elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                    self.start_pan(event.pos)
+                elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+                    self.end_pan()
+                elif event.type == pygame.MOUSEMOTION:
+                    self.pan_drag(event.pos)
+                elif event.type == pygame.MOUSEWHEEL:
+                    factor = 1.1 if event.y > 0 else 1 / 1.1
+                    self.zoom_at(factor, pygame.mouse.get_pos())
+                elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    self.running = False
 
             try:
                 self.add_world_point(next(self.graphic))

--- a/graphics.py
+++ b/graphics.py
@@ -33,6 +33,20 @@ class PygameGraphicDrawer(GraphicDrawer):
         self.iteration_count = 0
         self.max_iteration_count = max_iteration_count
 
+        self.zoom = 1.0
+        self.offset_x = 0
+        self.offset_y = 0
+
+    def zoom_in(self, factor: float = 1.1):
+        self.zoom *= factor
+
+    def zoom_out(self, factor: float = 1.1):
+        self.zoom /= factor
+
+    def pan(self, dx: int, dy: int):
+        self.offset_x += dx
+        self.offset_y += dy
+
     def show_iteration_count(self, iteration_count: int):
         surface = pygame.Surface((200, 50), pygame.SRCALPHA)
         surface.fill((20, 20, 20))
@@ -50,11 +64,26 @@ class PygameGraphicDrawer(GraphicDrawer):
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.running = False
+                elif event.type == pygame.KEYDOWN:
+                    if event.key in (pygame.K_EQUALS, pygame.K_PLUS, pygame.K_KP_PLUS):
+                        self.zoom_in()
+                    elif event.key in (pygame.K_MINUS, pygame.K_KP_MINUS):
+                        self.zoom_out()
+                    elif event.key == pygame.K_LEFT:
+                        self.pan(-10, 0)
+                    elif event.key == pygame.K_RIGHT:
+                        self.pan(10, 0)
+                    elif event.key == pygame.K_UP:
+                        self.pan(0, -10)
+                    elif event.key == pygame.K_DOWN:
+                        self.pan(0, 10)
 
             next_point = next(self.graphic)
 
             # scale coordinates
             next_point = (next_point[0] * self.screen_width // 12, next_point[1] * self.screen_height // 12)
+
+            next_point = (next_point[0] * self.zoom + self.offset_x, next_point[1] * self.zoom + self.offset_y)
 
             # convert center oriented coordinates to top left oriented coordinates
             next_point = (next_point[0] + self.screen_width // 2, self.screen_height // 2 - next_point[1])

--- a/graphics.py
+++ b/graphics.py
@@ -12,7 +12,7 @@ class GraphicDrawer(ABC):
         pass
 
 class PygameGraphicDrawer(GraphicDrawer):
-    def __init__(self, graphic: ChaosGameGraphic, screen_width: int, screen_height: int, fullscreen: bool, screen_caption: str):
+    def __init__(self, graphic: ChaosGameGraphic, screen_width: int, screen_height: int, fullscreen: bool, screen_caption: str, max_iteration_count: int = 100000):
         pygame.init()
 
         super().__init__(graphic)
@@ -31,6 +31,7 @@ class PygameGraphicDrawer(GraphicDrawer):
         self.clock = pygame.time.Clock()
         self.running = True
         self.iteration_count = 0
+        self.max_iteration_count = max_iteration_count
 
     def show_iteration_count(self, iteration_count: int):
         surface = pygame.Surface((200, 50), pygame.SRCALPHA)
@@ -66,7 +67,7 @@ class PygameGraphicDrawer(GraphicDrawer):
             pygame.draw.circle(self.screen, self.graphic.shape_color, next_point, 1)
 
             self.iteration_count += 1
-            if self.iteration_count >= 10 ** 6:
+            if self.iteration_count >= self.max_iteration_count:
                 self.running = False
 
             self.show_iteration_count(self.iteration_count)

--- a/graphics.py
+++ b/graphics.py
@@ -90,7 +90,7 @@ class PygameGraphicDrawer(GraphicDrawer):
 
     def pan(self, dx: int, dy: int):
         self.offset_x += dx
-        self.offset_y += dy
+        self.offset_y -= dy
 
     def start_pan(self, pos: tuple[int, int]):
         self._dragging = True

--- a/graphics.py
+++ b/graphics.py
@@ -36,6 +36,27 @@ class PygameGraphicDrawer(GraphicDrawer):
         self.zoom = 1.0
         self.offset_x = 0
         self.offset_y = 0
+        self.points: list[tuple[float, float]] = []
+
+    def world_to_screen(self, point: tuple[float, float]) -> tuple[int, int]:
+        x = point[0] * self.screen_width // 12
+        y = point[1] * self.screen_height // 12
+        x = x * self.zoom + self.offset_x + self.screen_width // 2
+        y = self.screen_height - (y * self.zoom + self.offset_y)
+        return int(x), int(y)
+
+    def screen_to_world(self, point: tuple[int, int]) -> tuple[float, float]:
+        x = (point[0] - self.screen_width // 2 - self.offset_x) / self.zoom
+        y = (self.screen_height - point[1] - self.offset_y) / self.zoom
+        x = x / (self.screen_width // 12)
+        y = y / (self.screen_height // 12)
+        return x, y
+
+    def add_world_point(self, point: tuple[float, float]):
+        self.points.append(point)
+
+    def add_screen_point(self, point: tuple[int, int]):
+        self.points.append(self.screen_to_world(point))
 
     def zoom_in(self, factor: float = 1.1):
         self.zoom *= factor
@@ -78,22 +99,16 @@ class PygameGraphicDrawer(GraphicDrawer):
                     elif event.key == pygame.K_DOWN:
                         self.pan(0, 10)
 
-            next_point = next(self.graphic)
+            try:
+                self.add_world_point(next(self.graphic))
+            except StopIteration:
+                self.running = False
 
-            # scale coordinates
-            next_point = (next_point[0] * self.screen_width // 12, next_point[1] * self.screen_height // 12)
+            self.screen.fill((0, 0, 0))
 
-            next_point = (next_point[0] * self.zoom + self.offset_x, next_point[1] * self.zoom + self.offset_y)
-
-            # convert center oriented coordinates to top left oriented coordinates
-            next_point = (next_point[0] + self.screen_width // 2, self.screen_height // 2 - next_point[1])
-
-            # move shape to bottom of screen
-            next_point = (next_point[0], next_point[1] + self.screen_height // 2)
-
-            next_point = (int(next_point[0]), int(next_point[1]))
-
-            pygame.draw.circle(self.screen, self.graphic.shape_color, next_point, 1)
+            for point in self.points:
+                screen_point = self.world_to_screen(point)
+                pygame.draw.circle(self.screen, self.graphic.shape_color, screen_point, 1)
 
             self.iteration_count += 1
             if self.iteration_count >= self.max_iteration_count:

--- a/shapes.py
+++ b/shapes.py
@@ -1,0 +1,18 @@
+from barnsley_fern import BarnsleyFern
+from sierpinski import SierpinskiTriangle, SierpinskiTriangleConfig
+
+
+DEFAULT_ITERATIONS = 100000
+
+def load_shape(name: str, iterations: int = DEFAULT_ITERATIONS):
+    name = name.lower()
+    if name in {"barnsley", "barnsley fern"}:
+        return BarnsleyFern(0, 0, iterations)
+    elif name in {"sierpinski", "sierpinski triangle"}:
+        triangle = [(0, 0), (6, 10), (12, 0)]
+        config = SierpinskiTriangleConfig(
+            triangle, "white", 1, iterations, "green"
+        )
+        return SierpinskiTriangle(config)
+    else:
+        raise ValueError(f"Unknown shape: {name}")

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from graphics import PygameGraphicDrawer
 from barnsley_fern import BarnsleyFern
 
@@ -29,4 +30,44 @@ def test_zoom_and_pan_methods():
     drawer.pan(-2, 2)
     assert drawer.offset_x == 3
     assert drawer.offset_y == -1
+
+
+def test_coordinate_conversions_and_storage():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 100, 100, False, "test")
+
+    world_pt = (1.0, 1.5)
+
+    # store point using world coordinates
+    drawer.add_world_point(world_pt)
+
+    drawer.zoom_in(2.0)
+    drawer.pan(10, 5)
+
+    # the stored world point should not change when zooming or panning
+    assert drawer.points[0] == world_pt
+
+    screen_pt = drawer.world_to_screen(world_pt)
+    back_to_world = drawer.screen_to_world(screen_pt)
+
+    assert back_to_world[0] == pytest.approx(world_pt[0])
+    assert back_to_world[1] == pytest.approx(world_pt[1])
+
+
+def test_add_screen_point():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 100, 100, False, "test")
+
+    drawer.zoom_in(1.5)
+    drawer.pan(20, -10)
+
+    screen_pt = (60, 70)
+    world_pt = drawer.screen_to_world(screen_pt)
+
+    drawer.add_screen_point(screen_pt)
+
+    assert drawer.points[-1][0] == pytest.approx(world_pt[0])
+    assert drawer.points[-1][1] == pytest.approx(world_pt[1])
 

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -1,0 +1,11 @@
+import os
+from graphics import PygameGraphicDrawer
+from barnsley_fern import BarnsleyFern
+
+
+def test_drawer_has_max_iteration_count():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 100, 100, False, "test", max_iteration_count=123)
+    assert drawer.max_iteration_count == 123
+

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from graphics import PygameGraphicDrawer
 from barnsley_fern import BarnsleyFern
+import pygame
 
 
 def test_drawer_has_max_iteration_count():
@@ -101,4 +102,26 @@ def test_pan_drag_updates_offset():
     assert drawer.offset_y == 5
 
     drawer.end_pan()
+
+
+def test_drawer_stop_method():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 100, 100, False, "test")
+
+    drawer.stop()
+    assert not drawer.running
+
+
+def test_update_stops_after_max_iterations():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0, max_iteration_count=1)
+    drawer = PygameGraphicDrawer(
+        shape, 100, 100, False, "test", max_iteration_count=1
+    )
+    drawer.screen = pygame.Surface((100, 100))
+
+    drawer.update()
+
+    assert not drawer.running
 

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -71,3 +71,34 @@ def test_add_screen_point():
     assert drawer.points[-1][0] == pytest.approx(world_pt[0])
     assert drawer.points[-1][1] == pytest.approx(world_pt[1])
 
+
+def test_zoom_at_keeps_cursor_point():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 200, 200, False, "test")
+
+    world_pt = (0.5, 0.5)
+    screen_pt = drawer.world_to_screen(world_pt)
+
+    drawer.zoom_at(2.0, screen_pt)
+
+    new_screen = drawer.world_to_screen(world_pt)
+    assert new_screen == screen_pt
+
+
+def test_pan_drag_updates_offset():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 100, 100, False, "test")
+
+    drawer.start_pan((10, 10))
+    drawer.pan_drag((15, 12))
+    assert drawer.offset_x == 5
+    assert drawer.offset_y == 2
+
+    drawer.pan_drag((14, 15))
+    assert drawer.offset_x == 4
+    assert drawer.offset_y == 5
+
+    drawer.end_pan()
+

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -9,3 +9,24 @@ def test_drawer_has_max_iteration_count():
     drawer = PygameGraphicDrawer(shape, 100, 100, False, "test", max_iteration_count=123)
     assert drawer.max_iteration_count == 123
 
+
+def test_zoom_and_pan_methods():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 100, 100, False, "test")
+
+    initial_zoom = drawer.zoom
+    drawer.zoom_in(2.0)
+    assert drawer.zoom == initial_zoom * 2.0
+
+    drawer.zoom_out(2.0)
+    assert drawer.zoom == initial_zoom
+
+    drawer.pan(5, -3)
+    assert drawer.offset_x == 5
+    assert drawer.offset_y == -3
+
+    drawer.pan(-2, 2)
+    assert drawer.offset_x == 3
+    assert drawer.offset_y == -1
+

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,0 +1,28 @@
+import pytest
+
+from shapes import load_shape
+from barnsley_fern import BarnsleyFern
+from sierpinski import SierpinskiTriangle
+
+
+def test_load_shape_barnsley():
+    shape = load_shape('barnsley')
+    assert isinstance(shape, BarnsleyFern)
+
+
+def test_load_shape_sierpinski():
+    shape = load_shape('sierpinski')
+    assert isinstance(shape, SierpinskiTriangle)
+
+
+def test_load_shape_invalid():
+    with pytest.raises(ValueError):
+        load_shape('unknown')
+
+from barnsley_fern import BarnsleyFern
+
+def test_barnsley_iter_limit():
+    fern = BarnsleyFern(0, 0, max_iteration_count=1)
+    next(fern)
+    with pytest.raises(StopIteration):
+        next(fern)


### PR DESCRIPTION
## Summary
- add shape loader helper and default iteration count
- allow specifying max iteration count in drawer and shapes
- create small pygame GUI with sidebar for shape selection
- document GUI usage in README
- add unit tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684977a90a70833392a0923466eb4e75