### PR TITLE
Allow stopping simulation and keep sidebar visible

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,14 @@ class ChaosGameApp:
             text="Run",
             manager=self.manager,
         )
+        self.stop_button = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(10, 130, 200, 30),
+            text="Stop",
+            manager=self.manager,
+        )
+        self.stop_button.disable()
+
+        self.drawer: PygameGraphicDrawer | None = None
         self.clock = pygame.time.Clock()
 
     def event_loop(self):
@@ -47,7 +55,17 @@ class ChaosGameApp:
                         and event.ui_element == self.run_button
                     ):
                         self.start_simulation()
+                    if (
+                        event.user_type == pygame_gui.UI_BUTTON_PRESSED
+                        and event.ui_element == self.stop_button
+                    ):
+                        self.stop_simulation()
+                if self.drawer:
+                    self.drawer.handle_event(event)
                 self.manager.process_events(event)
+
+            if self.drawer and self.drawer.running:
+                self.drawer.step()
             self.manager.update(time_delta)
             self.screen.fill((0, 0, 0))
             self.manager.draw_ui(self.screen)
@@ -62,15 +80,24 @@ class ChaosGameApp:
             iteration_count = DEFAULT_ITERATIONS
         shape_name = shape_name[0]
         shape = load_shape(shape_name, iteration_count)
-        drawer = PygameGraphicDrawer(
+        self.drawer = PygameGraphicDrawer(
             shape,
             self.width,
             self.height,
             self.fullscreen,
             shape_name,
             max_iteration_count=iteration_count,
+            screen=self.screen,
         )
-        drawer.draw()
+        self.stop_button.enable()
+        self.run_button.disable()
+
+    def stop_simulation(self):
+        if self.drawer:
+            self.drawer.stop()
+        self.drawer = None
+        self.stop_button.disable()
+        self.run_button.enable()
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -81,6 +81,7 @@ class ChaosGameApp:
             iteration_count = int(self.iter_input.get_text())
         except ValueError:
             iteration_count = DEFAULT_ITERATIONS
+        shape_name = shape_name[0]
         shape = load_shape(shape_name, iteration_count)
         self.drawer = PygameGraphicDrawer(
             shape,

--- a/app.py
+++ b/app.py
@@ -64,8 +64,11 @@ class ChaosGameApp:
                     self.drawer.handle_event(event)
                 self.manager.process_events(event)
 
-            if self.drawer and self.drawer.running:
-                self.drawer.step()
+            if self.drawer:
+                if self.drawer.running:
+                    self.drawer.step()
+                else:
+                    self.stop_simulation()
             self.manager.update(time_delta)
             self.screen.fill((0, 0, 0))
             self.manager.draw_ui(self.screen)
@@ -78,7 +81,6 @@ class ChaosGameApp:
             iteration_count = int(self.iter_input.get_text())
         except ValueError:
             iteration_count = DEFAULT_ITERATIONS
-        shape_name = shape_name[0]
         shape = load_shape(shape_name, iteration_count)
         self.drawer = PygameGraphicDrawer(
             shape,

--- a/graphics.py
+++ b/graphics.py
@@ -12,8 +12,9 @@ class GraphicDrawer(ABC):
         pass
 
 class PygameGraphicDrawer(GraphicDrawer):
-    def __init__(self, graphic: ChaosGameGraphic, screen_width: int, screen_height: int, fullscreen: bool, screen_caption: str, max_iteration_count: int = 100000):
-        pygame.init()
+    def __init__(self, graphic: ChaosGameGraphic, screen_width: int, screen_height: int, fullscreen: bool, screen_caption: str, max_iteration_count: int = 100000, screen: pygame.Surface | None = None):
+        if screen is None:
+            pygame.init()
 
         super().__init__(graphic)
 
@@ -22,11 +23,16 @@ class PygameGraphicDrawer(GraphicDrawer):
 
         self.fullscreen = fullscreen
         self.screen_caption = screen_caption
-        self.screen = pygame.display.set_mode(
-            (self.screen_width, self.screen_height),
-            pygame.FULLSCREEN if self.fullscreen else 0
-        )
-        pygame.display.set_caption(self.screen_caption)
+        if screen is None:
+            self.screen = pygame.display.set_mode(
+                (self.screen_width, self.screen_height),
+                pygame.FULLSCREEN if self.fullscreen else 0
+            )
+            pygame.display.set_caption(self.screen_caption)
+            self._manage_screen = True
+        else:
+            self.screen = screen
+            self._manage_screen = False
 
         self.clock = pygame.time.Clock()
         self.running = True
@@ -76,7 +82,7 @@ class PygameGraphicDrawer(GraphicDrawer):
 
     def pan(self, dx: int, dy: int):
         self.offset_x += dx
-        self.offset_y -= dy
+        self.offset_y += dy
 
     def start_pan(self, pos: tuple[int, int]):
         self._dragging = True
@@ -102,6 +108,46 @@ class PygameGraphicDrawer(GraphicDrawer):
         surface.blit(text, (0, 0))
         self.screen.blit(surface, (0, 0))
 
+    def handle_event(self, event: pygame.event.Event):
+        if event.type == pygame.QUIT:
+            self.running = False
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self.start_pan(event.pos)
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            self.end_pan()
+        elif event.type == pygame.MOUSEMOTION:
+            self.pan_drag(event.pos)
+        elif event.type == pygame.MOUSEWHEEL:
+            factor = 1.1 if event.y > 0 else 1 / 1.1
+            self.zoom_at(factor, pygame.mouse.get_pos())
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            self.running = False
+
+    def step(self):
+        if not self.running:
+            return
+
+        try:
+            self.add_world_point(next(self.graphic))
+        except StopIteration:
+            self.running = False
+            return
+
+        self.screen.fill((0, 0, 0))
+
+        for point in self.points:
+            screen_point = self.world_to_screen(point)
+            pygame.draw.circle(self.screen, self.graphic.shape_color, screen_point, 1)
+
+        self.iteration_count += 1
+        if self.iteration_count >= self.max_iteration_count:
+            self.running = False
+
+        self.show_iteration_count(self.iteration_count)
+
+    def stop(self):
+        self.running = False
+
     def _setup(self):
         # draw shape
         pass
@@ -109,43 +155,14 @@ class PygameGraphicDrawer(GraphicDrawer):
     def _loop(self):
         while self.running:
             for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    self.running = False
-                elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                    self.start_pan(event.pos)
-                elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
-                    self.end_pan()
-                elif event.type == pygame.MOUSEMOTION:
-                    self.pan_drag(event.pos)
-                elif event.type == pygame.MOUSEWHEEL:
-                    factor = 1.1 if event.y > 0 else 1 / 1.1
-                    self.zoom_at(factor, pygame.mouse.get_pos())
-                elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
-                    self.running = False
-
-            try:
-                self.add_world_point(next(self.graphic))
-            except StopIteration:
-                self.running = False
-
-            self.screen.fill((0, 0, 0))
-
-            for point in self.points:
-                screen_point = self.world_to_screen(point)
-                pygame.draw.circle(self.screen, self.graphic.shape_color, screen_point, 1)
-
-            self.iteration_count += 1
-            if self.iteration_count >= self.max_iteration_count:
-                self.running = False
-
-            self.show_iteration_count(self.iteration_count)
-
+                self.handle_event(event)
+            self.step()
             pygame.display.flip()
-
             self.clock.tick(500)
 
     def _quit(self):
-        pygame.quit()
+        if self._manage_screen:
+            pygame.quit()
 
     def draw(self):
         self._setup()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+import os
+import pygame
+import pygame_gui
+import pytest
+
+from app import ChaosGameApp
+from barnsley_fern import BarnsleyFern
+from sierpinski import SierpinskiTriangle
+
+
+def setup_module(module):
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    pygame.init()
+
+
+def teardown_module(module):
+    pygame.quit()
+
+
+def test_start_simulation_uses_selected_option_barnsley():
+    app = ChaosGameApp(width=100, height=100, fullscreen=False)
+    app.shape_dropdown.selected_option = "Barnsley Fern"
+    app.iter_input.set_text("1")
+    app.start_simulation()
+    assert isinstance(app.drawer.graphic, BarnsleyFern)
+    app.stop_simulation()
+
+
+def test_start_simulation_uses_selected_option_sierpinski():
+    app = ChaosGameApp(width=100, height=100, fullscreen=False)
+    app.shape_dropdown.selected_option = "Sierpinski Triangle"
+    app.iter_input.set_text("1")
+    app.start_simulation()
+    assert isinstance(app.drawer.graphic, SierpinskiTriangle)
+    app.stop_simulation()

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -102,3 +102,34 @@ def test_pan_drag_updates_offset():
 
     drawer.end_pan()
 
+
+def test_step_and_stop():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    import pygame
+
+    pygame.init()
+    screen = pygame.display.set_mode((50, 50))
+    shape = BarnsleyFern(0, 0, max_iteration_count=2)
+    drawer = PygameGraphicDrawer(shape, 50, 50, False, "test", screen=screen)
+
+    assert drawer.iteration_count == 0
+    drawer.step()
+    assert drawer.iteration_count == 1
+
+    drawer.stop()
+    drawer.step()
+    # iteration count should not change after stopping
+    assert drawer.iteration_count == 1
+
+
+def test_drawer_uses_provided_screen():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    import pygame
+
+    pygame.init()
+    screen = pygame.display.set_mode((60, 60))
+    shape = BarnsleyFern(0, 0)
+    drawer = PygameGraphicDrawer(shape, 60, 60, False, "test", screen=screen)
+
+    assert drawer.screen is screen
+

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -19,6 +19,14 @@ def test_load_shape_invalid():
     with pytest.raises(ValueError):
         load_shape('unknown')
 
+
+def test_load_shape_full_names():
+    shape = load_shape('Barnsley Fern')
+    assert isinstance(shape, BarnsleyFern)
+
+    shape = load_shape('Sierpinski Triangle')
+    assert isinstance(shape, SierpinskiTriangle)
+
 from barnsley_fern import BarnsleyFern
 
 def test_barnsley_iter_limit():


### PR DESCRIPTION
## Summary
- keep `PygameGraphicDrawer` zoom/pan consistent with tests
- add step-based drawing API and event handling
- avoid closing pygame window when managed externally
- integrate start/stop controls in GUI app
- add unit tests for new drawer functionality

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d3d6ee8883338713d222bee1575c